### PR TITLE
Hsdo 362

### DIFF
--- a/stanford_feeds_helper.admin.inc
+++ b/stanford_feeds_helper.admin.inc
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * Configuration interface for stanford_feeds_helper.
+ */
+
+function stanford_feeds_helper_configure() {
+  $form = array();
+
+  $form['stanford_feeds_helper_prevent_duplicates'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Prevent duplicate items.'),
+    '#description' => t("Prevent duplicate items from being created across all feeds importers."),
+    '#default_value' => variable_get("stanford_feeds_helper_prevent_duplicates", FALSE),
+  );
+
+
+  return system_settings_form($form);
+}

--- a/stanford_feeds_helper.admin.inc
+++ b/stanford_feeds_helper.admin.inc
@@ -14,6 +14,12 @@ function stanford_feeds_helper_configure() {
     '#default_value' => variable_get("stanford_feeds_helper_prevent_duplicates", FALSE),
   );
 
+  $form['stanford_feeds_helper_limit_field_collections'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Field collection limit.'),
+    '#description' => t("Set a limit to the number of field collections a single node can have created during import. Set to -1 for unlimited items."),
+    '#default_value' => variable_get("stanford_feeds_helper_limit_field_collections", -1),
+  );
 
   return system_settings_form($form);
 }

--- a/stanford_feeds_helper.module
+++ b/stanford_feeds_helper.module
@@ -4,8 +4,34 @@
  * Code for the Stanford Feeds Helper module.
  */
 
- /**
- * Implements hook_feeds_processor_targets_alter()
+/**
+ * Implements hook_menu().
+ */
+function stanford_feeds_helper_menu() {
+  $items = array();
+  $items['admin/config/stanford/stanford_feeds_helper'] = array(
+    'title' => 'Stanford Feeds Helper Configuration',
+    'page callback' => 'stanford_feeds_helper_configure',
+    'access arguments' => array('administer stanford_feeds_helper'),
+    'file' => "stanford_feeds_helper.admin.inc",
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function stanford_feeds_helper_permission() {
+  return array(
+    'administer stanford_feeds_helper' => array(
+      'title' => t('Administer Stanford Feeds Helper'),
+      'description' => t('Perform administration tasks for the feeds helper module.'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_feeds_processor_targets_alter().
  */
 function stanford_feeds_helper_feeds_processor_targets_alter(&$targets, $entity_type, $bundle_name) {
   // Load up.
@@ -17,7 +43,7 @@ function stanford_feeds_helper_feeds_processor_targets_alter(&$targets, $entity_
     $files = drupal_system_listing('/.*\.inc$/', $path, 'name', 0);
     foreach ($files as $file) {
       if (strstr($file->uri, '/mappers/')) {
-        require_once (DRUPAL_ROOT . '/' . $file->uri);
+        require_once DRUPAL_ROOT . '/' . $file->uri;
       }
     }
   }
@@ -45,7 +71,7 @@ function stanford_feeds_helper_feeds_processor_targets_alter(&$targets, $entity_
 }
 
 /**
- * Process Field Collection items
+ * Process Field Collection items.
  */
 function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $value) {
   $sub_targets = &drupal_static(__FUNCTION__, array());
@@ -87,7 +113,7 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
       }
 
       // Zero out.
-      $field_collection_item = null;
+      $field_collection_item = NULL;
 
       if (isset($field['und'][$delta]['entity'])) {
         $field_collection_item = $field['und'][$delta]['entity'];
@@ -118,7 +144,7 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
       if (isset($_sub_targets[$sub_target]['callback']) && function_exists($_sub_targets[$sub_target]['callback'])) {
         $callback = $_sub_targets[$sub_target]['callback'];
 
-        // Normalize
+        // Normalize.
         if (!is_array($value[$delta])) {
           $value[$delta] = array($value[$delta]);
         }
@@ -143,8 +169,8 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
         $callback($source, $field_collection_item, $sub_target, $value[$delta], $sub_mapping);
       }
 
-      // No need to save the field collection here. Just wait until the node is saved.
-      // If we save the FC here we get a huge performance degregation.
+      // No need to save the field collection here. Just wait until the node is
+      // saved. If we save the FC here we get a huge performance degregation.
       $field['und'][$delta]['entity'] = $field_collection_item;
 
       // Break when only hitting the max delta.
@@ -166,9 +192,11 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
 }
 
 /**
- * Multiple field values are a pain in the rear. They are additive and we do not
- * always want them to be. This function targets a couple of items and truncates
- * their values before saving the new ones.
+ * Multiple field values are a pain in the rear.
+ *
+ * They are additive and we do not always want them to be. This function targets
+ * a couple of items and truncates their values before saving the new ones.
+ *
  * @param $target
  * @param $entity
  * @param $field
@@ -246,7 +274,7 @@ function stanford_feeds_helper_field_collection_file_feeds_set_target($source, $
       watchdog('feeds', check_plain($e->getMessage()));
     }
     if ($file) {
-      $field['und'][$i] = (array)$file;
+      $field['und'][$i] = (array) $file;
       $field['und'][$i]['display'] = 1; // @todo: Figure out how to properly populate this field.
       if ($info['cardinality'] == 1) {
         break;
@@ -256,4 +284,42 @@ function stanford_feeds_helper_field_collection_file_feeds_set_target($source, $
   }
   $entity->{$target} = $field;
 
+}
+
+/**
+ * Implements hook_feeds_presave().
+ */
+function stanford_feeds_helper_feeds_presave($source, $entity, $item) {
+
+  // Check if duplicate reduction is on. If not we end our journey here.
+  if (!variable_get("stanford_feeds_helper_prevent_duplicates", FALSE)) {
+    return;
+  }
+
+  // It is not a fun journey to partake without the feeds_item information.
+  if (!isset($entity->feeds_item)) {
+    return;
+  }
+
+  // GUID and Importer ID are used as keys to look for duplicates in the DB.
+  $guid = $entity->feeds_item->guid;
+  $importer_nid = $entity->feeds_item->feed_nid;
+
+  // Check to see if another importer already has this GUID by looking in the
+  // feeds_item table for a matching GUID that is not THIS importer. We have to
+  // find other importers with the same GUID as it would prevent updating if
+  // we matched with ourselves.
+  $results = db_select("feeds_item", "fi")
+    ->fields("fi", array("entity_id"))
+    ->condition("guid", $guid)
+    ->condition("feed_nid", $importer_nid, "!=")
+    ->execute()
+    ->rowCount();
+
+  // We found a match somewhere else. Prevent this thing from saving.
+  if ($results >= 1) {
+    $entity->feeds_item->skip = TRUE;
+  }
+
+  // All quiet on the western front. Nothing to do.
 }

--- a/stanford_feeds_helper.module
+++ b/stanford_feeds_helper.module
@@ -10,8 +10,10 @@
 function stanford_feeds_helper_menu() {
   $items = array();
   $items['admin/config/stanford/stanford_feeds_helper'] = array(
-    'title' => 'Stanford Feeds Helper Configuration',
-    'page callback' => 'stanford_feeds_helper_configure',
+    'title' => 'Stanford Feeds Helper',
+    'description' => t("Configuration settings for feeds."),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('stanford_feeds_helper_configure'),
     'access arguments' => array('administer stanford_feeds_helper'),
     'file' => "stanford_feeds_helper.admin.inc",
   );


### PR DESCRIPTION
#### Adds a hook_feeds_presave and some logic to prevent duplicate nodes from being created across multiple importers.

_To test:_
- Find or build any existing site that uses stanford_feeds_helper
- check out this branch
- flush all caches heavily
- Give yourself the 'administer stanford_feeds_helper' permission if you are not user 1
- Go to admin/configure/stanford/stanford_feeds_helper and check the prevent duplicates checkbox
- Create an events importer and import a bunch of event nodes
- Create a second importer with the exact same configuration as the first one
- Trying to import should give you the message "no new nodes"
- Go back to the configuration setting page admin/configure/stanford/stanford_feeds_helper and uncheck the prevent duplicates checkbox
- Go back to the second importer that was created and try to import again
- You should get the message that a bunch of new nodes have been created.
