### PR TITLE
added the ability to attach multiple feeds to a single node type

### DIFF
--- a/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.info
+++ b/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.info
@@ -1,0 +1,5 @@
+name = Stanford Feeds Helper Multple
+description = Allow multiple feed sources to attache to a single node type.
+core = 7.x
+package = Stanford
+version = 7.x-1.2-dev

--- a/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
+++ b/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
@@ -181,6 +181,12 @@ function stanford_feeds_helper_multiple_feeds_get_importer_ids($content_type, $f
   $all_importers = _feeds_importer_digest();
   $importers = array();
   foreach ($all_importers as $importer => $type) {
+    /** @var FeedsImporter $feed_importer */
+    $feed_importer = feeds_importer($importer);
+    if ($feed_importer->disabled) {
+      continue;
+    }
+
     if ($type == $content_type) {
       $importers[$importer] = $importer;
     }

--- a/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
+++ b/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
@@ -209,7 +209,7 @@ function stanford_feeds_helper_multiple_feeds_get_importer_ids($content_type, $f
  *
  * @see https://www.drupal.org/node/1127696#comment-11819331
  */
-function _stanford_feeds_helper_multiple_feeds_get_importer_weights($importers, $sorted = TRUE) {
+function _stanford_feeds_helper_multiple_feeds_get_importer_weights(array $importers, $sorted = TRUE) {
   foreach (feeds_importer_load_all() as $importer) {
     if (isset($importers[$importer->id])) {
       $importer_weights[$importer->id] = isset($importer->config['weight']) ?
@@ -286,4 +286,3 @@ function stanford_feeds_helper_multiple_feeds_import_form_submit($form, &$form_s
     feeds_source($importer_id, $form['#feed_nid'])->startImport();
   }
 }
-

--- a/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
+++ b/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
@@ -27,7 +27,7 @@ function stanford_feeds_helper_multiple_node_prepare($node) {
  * @see https://www.drupal.org/node/1127696#comment-11819331
  */
 function stanford_feeds_helper_multiple_form_alter(&$form, &$form_state, $form_id) {
-  if (strpos($form_id, 'node_form') === FALSE && isset($form['feeds'])) {
+  if (strpos($form_id, 'node_form') === FALSE || !isset($form['feeds'])) {
     return;
   }
   if ($importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($form['#node']->type)) {

--- a/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
+++ b/modules/stanford_feeds_helper_multiple/stanford_feeds_helper_multiple.module
@@ -1,0 +1,289 @@
+<?php
+
+/**
+ * @file
+ * stanford_feeds_helper_multiple.module
+ */
+
+/**
+ * Implements hook_node_prepare().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_node_prepare($node) {
+  if ($importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($node->type)) {
+    $node->feeds = array();
+    foreach ($importer_ids as $importer_id) {
+      $source = feeds_source($importer_id, empty($node->nid) ? 0 : $node->nid);
+      $node->feeds[$importer_id] = array();
+      $node->feeds[$importer_id] += $source->configDefaults();
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_form_alter(&$form, &$form_state, $form_id) {
+  if (strpos($form_id, 'node_form') === FALSE && isset($form['feeds'])) {
+    return;
+  }
+  if ($importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($form['#node']->type)) {
+    $form['feeds'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Feed'),
+      '#tree' => TRUE,
+      '#weight' => 0,
+    );
+
+    // Enable uploads.
+    if (count($importer_ids)) {
+      $form['#attributes']['enctype'] = 'multipart/form-data';
+    }
+
+    foreach ($importer_ids as $importer_id) {
+      // Build form.
+      $source = feeds_source($importer_id, empty($form['#node']->nid) ? 0 : $form['#node']->nid);
+      $form['feeds'][$importer_id] = $source->configForm($form_state);
+      $class = get_class(feeds_importer($importer_id)->fetcher);
+      $form['feeds'][$importer_id][$class]['source']['#title'] = $form['feeds'][$importer_id][$class]['source']['#title']
+        . ' - '
+        . $source->importer->config['name'];
+      $form['feeds'][$importer_id][$class]['source']['#required'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Implements hook_node_validate().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_node_validate($node, $form, &$form_state) {
+  if (!$importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($node->type)) {
+    return;
+  }
+
+  // Keep a copy of the title for subsequent node creation stages.
+  $last_title = &drupal_static('feeds_node_last_title');
+  $last_feeds = &drupal_static('feeds_node_last_feeds');
+
+  // Node module magically moved $form['feeds'] to $node->feeds :P.
+  // configFormValidate may modify $last_feed, smuggle it to update/insert stage
+  // through a static variable.
+  $last_feeds = isset($node->feeds) ? $node->feeds : array();
+
+  $trimmed_node_title = trim($node->title);
+
+  // On validation stage we are working with a FeedsSource object that is
+  // not tied to a nid - when creating a new node there is no
+  // $node->nid at this stage.
+  foreach ($importer_ids as $importer_id) {
+    $class = get_class(feeds_importer($importer_id)->fetcher);
+    if (!$form['feeds'][$importer_id][$class]['source']['#required']) {
+      break;
+    }
+
+    /** @var FeedsSource $source */
+    $source = feeds_source($importer_id);
+    $source->configFormValidate($last_feeds[$importer_id]);
+
+    // If node title is empty, try to retrieve title from feed.
+    if ($trimmed_node_title == '') {
+      try {
+        $source->addConfig($last_feeds[$importer_id]);
+        if (!$last_title = $source->preview()->title) {
+          throw new Exception(t('Could not retrieve title from feed'));
+        }
+      }
+      catch (Exception $e) {
+        drupal_set_message($e->getMessage(), 'error');
+        form_set_error('title', t('Could not retrieve title from feed.'), array('error' => array('title')));
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_node_insert().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_node_insert($node) {
+  // Source attached to node.
+  feeds_node_update($node);
+  if (isset($node->feeds) && ($importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($node->type, $node->nid))) {
+    foreach ($importer_ids as $importer_id) {
+      /** @var FeedsSource $source */
+      $source = feeds_source($importer_id, $node->nid);
+
+      $source->addConfig($node->feeds[$importer_id]);
+      $source->save();
+
+      // Start import if requested.
+      if (feeds_importer($importer_id)->config['import_on_create'] && !isset($node->feeds['suppress_import'])) {
+        $source->startImport();
+      }
+      // Schedule the source.
+      $source->schedule();
+    }
+  }
+}
+
+/**
+ * Implements hook_node_update().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_node_update($node) {
+  // Source attached to node.
+  if (isset($node->feeds) && ($importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($node->type))) {
+    foreach ($importer_ids as $importer_id) {
+      $source = feeds_source($importer_id, $node->nid);
+      // Config may be empty if defined so by importer.
+      if ($node->feeds[$importer_id]) {
+        $source->addConfig($node->feeds[$importer_id]);
+      }
+      $source->save();
+    }
+  }
+}
+
+/**
+ * Implements hook_node_delete().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_node_delete($node) {
+  if ($importer_ids = db_query("SELECT id FROM {feeds_source} WHERE feed_nid = :nid", array(':nid' => $node->nid))) {
+    foreach ($importer_ids as $row) {
+      feeds_source($row->id, $node->nid)->delete();
+    }
+  }
+}
+
+/**
+ * Gets an enabled importer configuration by content type.
+ *
+ * @param string $content_type
+ *   A node type string.
+ * @param int $feed_nid
+ *   Nid for feed.
+ *
+ * @return array
+ *   A list of FeedsImporters attached to the given content type.
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_feeds_get_importer_ids($content_type, $feed_nid = NULL) {
+  $all_importers = _feeds_importer_digest();
+  $importers = array();
+  foreach ($all_importers as $importer => $type) {
+    if ($type == $content_type) {
+      $importers[$importer] = $importer;
+    }
+  }
+  // Sort those importers by weight.
+  if (!empty($importers)) {
+    $weights = _stanford_feeds_helper_multiple_feeds_get_importer_weights($importers);
+    // Sort these arrays by key, then sort together.
+    ksort($weights);
+    ksort($importers);
+    array_multisort($weights, $importers);
+  }
+  return $importers;
+}
+
+/**
+ * Get importer.
+ *
+ * @param array $importers
+ *   Importers on the node to get weights.
+ * @param bool $sorted
+ *   If to sort by weight.
+ *
+ * @return mixed
+ *   Importers with weights as properties and sorted if told to.
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function _stanford_feeds_helper_multiple_feeds_get_importer_weights($importers, $sorted = TRUE) {
+  foreach (feeds_importer_load_all() as $importer) {
+    if (isset($importers[$importer->id])) {
+      $importer_weights[$importer->id] = isset($importer->config['weight']) ?
+        $importer->config['weight'] : '0';
+    }
+  }
+  if ($sorted) {
+    asort($importer_weights);
+  }
+  return $importer_weights;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_form_feeds_import_tab_form_alter(&$form, &$form_state, $form_id) {
+  $node = node_load($form['#feed_nid']);
+
+  $importer_ids = stanford_feeds_helper_multiple_feeds_get_importer_ids($node->type, $node->nid);
+  if (count($importer_ids) < 2) {
+    return;
+  }
+  $total_progress = 0;
+  unset($form['source_status']);
+
+  foreach ($importer_ids as $importer_id => $weight) {
+    $source = feeds_source($importer_id, $node->nid);
+    $form[$importer_id]['source_status'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('@source_name: Status', array(
+        '@source_name' => $source->importer->config['name'],
+      )),
+      '#tree' => TRUE,
+      '#value' => feeds_source_status($source),
+    );
+    $progress = $source->progressImporting();
+    $total_progress += $progress;
+  }
+
+  $options = array();
+  foreach ($importer_ids as $importer_id => $weight) {
+    $source = feeds_source($importer_id, $node->nid);
+    $options[$importer_id] = $source->importer->config['name'];
+  }
+  $form['importer_ids'] = array(
+    '#type' => 'checkboxes',
+    '#options' => $options,
+    '#default_value' => array_keys($options),
+    '#title' => t('Sources'),
+    '#description' => t('Select the sources to import.'),
+  );
+
+  $progress = $total_progress / count($importer_ids);
+  if ($progress !== FEEDS_BATCH_COMPLETE) {
+    $form['actions']['submit']['#disabled'] = TRUE;
+    $form['actions']['submit']['#value'] = t('Importing (@progress %)',
+      array('@progress' => number_format(100 * $progress, 0)));
+  }
+
+  $form['#submit'] = array('stanford_feeds_helper_multiple_feeds_import_form_submit');
+  return $form;
+}
+
+/**
+ * Feeds Tab import submit handler.
+ *
+ * @see https://www.drupal.org/node/1127696#comment-11819331
+ */
+function stanford_feeds_helper_multiple_feeds_import_form_submit($form, &$form_state) {
+  $form_state['redirect'] = $form['#redirect'];
+  foreach (array_filter($form_state['values']['importer_ids']) as $importer_id) {
+    feeds_source($importer_id, $form['#feed_nid'])->startImport();
+  }
+}
+


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allows for two or more importers to attach to a single node type.

# Needed By (Date)
- whenever

# Urgency
- not crtical

# Steps to Test
1. Checkout branch & enable stanford_feeds_helper_multiple module
2. Create a node type for the content and a node type for the importer (or use existing types)
3. create 2 or more feeds sources to grab two different url sources (like one is an RSS, one is an xml)
4. Create a new node of your importer
5. you should see two url fields, one from each feed source.
6. populate one or both fields and save. the feed should import