### PR TITLE
HS-7 Set field collections empty so new data is created fresh and fix…

### DIFF
--- a/stanford_feeds_helper.module
+++ b/stanford_feeds_helper.module
@@ -103,7 +103,12 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
 
   // Iterate over all values.
   $delta = 0;
-  $field = isset($entity->$target) ? $entity->$target : array();
+  // Set the field to an empty array because when we're importing a field
+  // collection. If we leave the original field values, we can get some orphaned
+  // data that we dont want. For example, if the first of 4 field collections is
+  // deleted from the feed source, we we want to start fresh so that the outcome
+  // leaves only 3 entities, not 4.
+  $field = array();
   try {
 
     while (isset($value[$delta])) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Rebuild the field collection data when the field is imported.

# Needed By (Date)
- Sooooon

# Urgency
- Kinda high

# Steps to Test
I created an [xml file gist](https://gist.github.com/pookmish/84e6c6ffe76b5742df38b8b4ff3a0a87) that can be used for testing purposes. 
0. Stay on the 1.x branch to validate functionality as desired.
1. Take any site using the course importer
2. Change it from http to file upload fetcher
3. upload the gist file to import the one course
4. review the course and see the 5 course sections
5. delete a section from the file and re-upload & import
6. review the course again. there should still be 5 sections. 
Heres an explanation of what is happening:
 - section `a`, `b`, `c`, `d`, & `e` are imported. If i delete `b` the importer will import `a`, `c`, `d` & `e`. the 5th delta on the field still contains data from `e`. So the field outcome is `a`, `c`, `d`, `e`, `e`. Thats because the field processor doesn't unset any pre-existing data.

7. Now checkout this branch.
8. run the importer again with the file that has the removed section (skip hash check might help here)
9. review the course and ensure only 4 sections exist and they are the correct sections.
10. Review the revisions on the course to validate the deleted section still lives somewhere.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)