### PR TITLE
HS-51 Fixed course importer with existing entities

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,24 +1,130 @@
 engines:
+  # https://docs.codeclimate.com/docs/eslint
+  # ES Linting requires an .eslintrc file to tweak checks.
   eslint:
-    enabled: true
+    enabled: false
   csslint:
     enabled: true
-  phpcodesniffer:
-    enabled: true
-    config:
-      file_extensions: "php,inc,install,module,profile"
-      standard: "Drupal"
-  phpmd:
-    enabled: true
-    config:
-      file_extensions:
-      - inc
-      - module
-      - profile
-      - php
-      - install
+    checks:
+      overqualified-elements:
+        enabled: false
+      order-alphabetical:
+        enabled: false
+      adjoining-classes:
+        enabled: false
+      fallback-colors:
+        enabled: false
+      ids:
+        enabled: false
+      regex-selectors:
+        enabled: false
+  # We don't lint our coffee. Eew.
+  coffeelint:
+    enabled: false
+  # SCSS Lint requires a .scss-lint.yml file in the repo in order to tweak settings.
+  # Withouth the .scss-lint.yml file it will run with the defaults.
+  # Defaults file: https://github.com/brigade/scss-lint/blob/master/config/default.yml
   scss-lint:
     enabled: true
+    checks:
+      IdSelector:
+        enabled: false
+      SelectorFormat:
+        enabled: false
+      NestingDepth:
+        enabled: false
+      MergeableSelector:
+        enabled: false
+      ColorVariable:
+        enabled: false
+      PropertySortOrder:
+        enabled: false
+      SelectorDepth:
+        enabled: false
+      QualifyingElement:
+        enabled: false
+      VendorPrefix:
+        enabled: false
+      LeadingZero:
+        enabled: false
+      HexLength:
+        enabled: false
+      PseudoElement:
+        enabled: false
+  phpcodesniffer:
+    enabled: true
+    checks:
+      Drupal Commenting FunctionComment TypeHintMissing:
+        enabled: false
+      Drupal Commenting FunctionComment IncorrectTypeHint:
+        enabled: false
+      DrupalPractice Commenting CommentEmptyLine SpacingAfter:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName ScopeNotCamelCaps:
+        enabled: false
+      Drupal NamingConventions ValidClassName StartWithCaptial:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName NotCamelCaps:
+        enabled: false
+      DrupalPractice General ClassName ClassPrefix:
+        enabled: false
+      Drupal NamingConventions ValidClassName NoUnderscores:
+        enabled: false
+    config:
+      file_extensions: "php,inc,install,module,profile"
+      standard: "Drupal,DrupalPractice"
+  phpmd:
+    enabled: true
+    checks:
+      Design/WeightedMethodCount:
+        enabled: false
+      CleanCode/StaticAccess:
+        enabled: false
+      CleanCode/ElseExpression:
+        enabled: false
+      CleanCode/BooleanArgumentFlag:
+        enabled: false
+      UnusedFormalParameter:
+        enabled: false
+    config:
+      # https://phpmd.org/rules/index.html
+      # The following sets include everything except the controversial set.
+      # We can configure these further through .xml files. See docs.
+      rulesets: "cleancode,codesize,design,naming,unusedcode"
+      # Include special Drupal file extensions.
+      file_extensions: "inc,module,profile,php,install"
+  # https://docs.codeclimate.com/docs/phan
+  phan:
+    enabled: true
+    config:
+      file_extensions: "php,module,profile,inc,install"
+      # minimum-severity: 1
+      ignore-undeclared: true
+      # quick: true
+      # backward-compatiility-checks: true
+      # dead-code-detection: true
+  # https://docs.codeclimate.com/docs/duplication
+  duplication:
+    enabled: true
+    # exclude_paths:
+    #   - examples/
+    config:
+      languages:
+        javascript:
+          mass_threshold: 50
+          # count_threshold: 3
+        php:
+          mass_threshold: 60
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - FIXME
+      - BUG
+      - TODO
+      - todo
+      - dpm
+      - dsm
 ratings:
   paths:
   - "**.inc"
@@ -26,11 +132,10 @@ ratings:
   - "**.profile"
   - "**.php"
   - "**.install"
-  - "**.css"
   - "**.scss"
   - "**.sass"
   - "**.js"
-##exclude these files/paths
+# exclude these files/paths
 exclude_paths:
 - "**.features.**"
 - "**.views_default.inc"
@@ -41,3 +146,10 @@ exclude_paths:
 - "test/**/*"
 - "**/vendor/**/*"
 - "**.min.*"
+- "tests/"
+- "spec/"
+- "**/vendor/"
+- "**.api.php"
+- "*.twig"
+- "**.tpl.php"
+- "**.strongarm.inc"

--- a/stanford_feeds_helper.module
+++ b/stanford_feeds_helper.module
@@ -225,9 +225,9 @@ function _stanford_feeds_helper_get_field($entity, $target){
   // deleted from the feed source, we we want to start fresh so that the outcome
   // leaves only 3 entities, not 4. But we only want to reset the field one time
   // for each parent entity.
-  if ($static_id !== $entity_id) {
+  if ("$static_id-$target" !== "$entity_id-$target") {
     $field = array();
-    $static_id = $entity_id;
+    $static_id = "$entity_id-$target";
   }
 
   return $field;

--- a/stanford_feeds_helper.module
+++ b/stanford_feeds_helper.module
@@ -103,12 +103,7 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
 
   // Iterate over all values.
   $delta = 0;
-  // Set the field to an empty array because when we're importing a field
-  // collection. If we leave the original field values, we can get some orphaned
-  // data that we dont want. For example, if the first of 4 field collections is
-  // deleted from the feed source, we we want to start fresh so that the outcome
-  // leaves only 3 entities, not 4.
-  $field = array();
+  $field = _stanford_feeds_helper_get_field($entity, $target);
   try {
 
     while (isset($value[$delta])) {
@@ -196,6 +191,46 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
   }
 
   $entity->{$target} = $field;
+}
+
+/**
+ * Get the field data or an empty array to start fresh.
+ *
+ * @param object $entity
+ *   Parent entity.
+ * @param string $target
+ *   Target field.
+ *
+ * @return array
+ *   Existing data if we're in the middle of editing.
+ */
+function _stanford_feeds_helper_get_field($entity, $target){
+  // Normal behavior for a new entity.
+  $field = isset($entity->$target) ? $entity->$target : array();
+
+  $static_id = &drupal_static(__FUNCTION__, NULL);
+  $entity_id = 0;
+  // Only existing entities will have ID values. This are the ones we have
+  // trouble with.
+  if (!empty($entity->nid)) {
+    $entity_id = $entity->nid;
+  }
+  elseif (!empty($entity->item_id)) {
+    $entity_id = $entity->item_id;
+  }
+
+  // Set the field to an empty array because when we're importing a field
+  // collection. If we leave the original field values, we can get some orphaned
+  // data that we dont want. For example, if the first of 4 field collections is
+  // deleted from the feed source, we we want to start fresh so that the outcome
+  // leaves only 3 entities, not 4. But we only want to reset the field one time
+  // for each parent entity.
+  if ($static_id !== $entity_id) {
+    $field = array();
+    $static_id = $entity_id;
+  }
+
+  return $field;
 }
 
 /**

--- a/stanford_feeds_helper.module
+++ b/stanford_feeds_helper.module
@@ -204,7 +204,7 @@ function stanford_feeds_helper_feeds_set_target($source, &$entity, $target, $val
  * @return array
  *   Existing data if we're in the middle of editing.
  */
-function _stanford_feeds_helper_get_field($entity, $target){
+function _stanford_feeds_helper_get_field($entity, $target) {
   // Normal behavior for a new entity.
   $field = isset($entity->$target) ? $entity->$target : array();
 
@@ -225,7 +225,7 @@ function _stanford_feeds_helper_get_field($entity, $target){
   // deleted from the feed source, we we want to start fresh so that the outcome
   // leaves only 3 entities, not 4. But we only want to reset the field one time
   // for each parent entity.
-  if ("$static_id-$target" !== "$entity_id-$target") {
+  if ($static_id !== "$entity_id-$target") {
     $field = array();
     $static_id = "$entity_id-$target";
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Previous fixes to make course importer function correctly were futile. Now all the courses import with empty data. It seems that setting the field to an empty array all the time is bad. the importer will run through different fields on the same field collection item and only the last field mapped to the entity will remain. This PR changes it so that the field is only reset one time for each entity and only for existing entities.
NOTE: I'll be checking this branch out on the live site to fix the site for the weekend.

# Needed By (Date)
- ASAP

# Urgency
- Very High

# Steps to Test

1. Clone `jumpstart-sts` site.
2. checkout the main branch of this repo.
3. run the course importer. 
4. review `/node/1959/edit` to see most of the section data is gone
5. checkout this branch.
6. clear hash values from the feeds table `drush sqlq "update feeds_item set hash=0"`
7. run the course importer again
8. view that node to see the section data has populated.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)